### PR TITLE
Bug fixes

### DIFF
--- a/gerberex/am_expression.py
+++ b/gerberex/am_expression.py
@@ -49,7 +49,7 @@ class AMConstantExpression(AMExpression):
         return self
     
     def to_gerber(self, settings=None):
-        return '%.6g' % self._value
+        return '%.6f' % self._value
 
     def to_instructions(self):
         return [(OpCode.PUSH, self._value)]

--- a/gerberex/am_primitive.py
+++ b/gerberex/am_primitive.py
@@ -56,7 +56,7 @@ class AMCirclePrimitiveDef(AMPrimitiveDef):
         diameter = modifiers[1]
         center_x = modifiers[2]
         center_y = modifiers[3]
-        rotation = modifiers[4]
+        rotation = modifiers[4] if len(modifiers)>4 else AMConstantExpression(float(0))
         return cls(code, exposure, diameter, center_x, center_y, rotation)
 
     def __init__(self, code, exposure, diameter, center_x, center_y, rotation):

--- a/gerberex/composition.py
+++ b/gerberex/composition.py
@@ -7,6 +7,7 @@ from functools import reduce
 from gerber.cam import FileSettings
 from gerber.gerber_statements import EofStmt
 from gerber.excellon_statements import *
+from gerber.excellon import DrillSlot, DrillHit
 import gerberex.rs274x
 import gerberex.excellon
 import gerberex.dxf
@@ -149,7 +150,10 @@ class DrillComposition(Composition):
                 yield ToolSelectionStmt(t.number).to_excellon(self.settings)
                 for h in self.hits:
                     if h.tool.number == t.number:
-                        yield CoordinateStmt(*h.position).to_excellon(self.settings)
+                        if type(h) == DrillSlot:
+                            yield SlotStmt(*h.start, *h.end).to_excellon(self.settings)
+                        elif type(h) == DrillHit:
+                            yield CoordinateStmt(*h.position).to_excellon(self.settings)
                 for num, statement in self.dxf_statements:
                     if num == t.number:
                         yield statement.to_excellon(self.settings)


### PR DESCRIPTION
Hello,

Thank you for this great extension to pcb-tools.

I encountered two bugs and an incompatibility issue.
Here are fixes for those problems.

About commit 0854d35, the "e" character of the scientific notation is causing troubles with some CAM viewers. It is occuring when some distances are very small but not null (such as pads rounded with 4 circles). I suspect it is might be a general bug with pcb-tools.
I can provide screenshots of this bug if you want more details.

Kind regards,
Mikaël