### PR TITLE
Fix crashes in gerber output and excellon parser code

### DIFF
--- a/gerberex/am_expression.py
+++ b/gerberex/am_expression.py
@@ -49,6 +49,8 @@ class AMConstantExpression(AMExpression):
         return self
     
     def to_gerber(self, settings=None):
+        if isinstance(self._value, str):
+            return self._value
         gerber = '%.6g' % self._value
         return '%.6f' % self._value if 'e' in gerber else gerber
 

--- a/gerberex/excellon.py
+++ b/gerberex/excellon.py
@@ -114,8 +114,8 @@ class ExcellonFileEx(ExcellonFile):
                 if isinstance(stmt, ToolSelectionStmt):
                     current_tool = file.tools[stmt.tool]
                 elif isinstance(stmt, DrillModeStmt):
-                    rout = make_rout(status, rout_statements)
-                    rout_statements = []
+                    rout = make_rout(status, rout_nodes)
+                    rout_nodes = []
                     if rout is not None:
                         yield rout
                     status = STAT_DRILL
@@ -137,7 +137,7 @@ class ExcellonFileEx(ExcellonFile):
                     status = STAT_ROUT_DOWN
                 elif isinstance(stmt, RetractWithClampingStmt) or isinstance(stmt, RetractWithoutClampingStmt):
                     rout = make_rout(status, rout_nodes)
-                    rout_statements = []
+                    rout_nodes = []
                     if rout is not None:
                         yield rout
                     status = STAT_ROUT_UP


### PR DESCRIPTION
am_expression.py will crash with gerber files that contain comments like these, generated by a recent KiCAD:
```
[...]
G04 APERTURE LIST*
G04 Aperture macros list*
%AMRoundRect*
0 Rectangle with rounded corners*   <<<< here ====
0 $1 Rounding radius*
0 $2 $3 $4 $5 $6 $7 $8 $9 X,Y pos of 4 corners*
0 Add a 4 corners polygon primitive as box body*
4,1,4,$2,$3,$4,$5,$6,$7,$8,$9,$2,$3,0*
0 Add four circle primitives for the rounded corners*
1,1,$1+$1,$2,$3*
1,1,$1+$1,$4,$5*
[...]
```

Also, excellon.py did not work for me. This patch makes it not crash during parsing, but please review my changes--I was unsure of how this code was meant to work in the first place.